### PR TITLE
Load by relative path if require fails

### DIFF
--- a/lib/puppet/parser/functions/ip_address.rb
+++ b/lib/puppet/parser/functions/ip_address.rb
@@ -1,5 +1,11 @@
 # ex: syntax=ruby ts=2 sw=2 si et
-require 'puppetx/ip'
+begin
+  require 'puppetx/ip'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppetx/ip')
+end
 
 module Puppet::Parser::Functions
   newfunction(:ip_address, :type => :rvalue) do |args|

--- a/lib/puppet/parser/functions/ip_broadcast.rb
+++ b/lib/puppet/parser/functions/ip_broadcast.rb
@@ -1,5 +1,11 @@
 # ex: syntax=ruby ts=2 sw=2 si et
-require 'puppetx/ip'
+begin
+  require 'puppetx/ip'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppetx/ip')
+end
 
 module Puppet::Parser::Functions
   newfunction(:ip_broadcast, :type => :rvalue) do |args|

--- a/lib/puppet/parser/functions/ip_netmask.rb
+++ b/lib/puppet/parser/functions/ip_netmask.rb
@@ -1,5 +1,11 @@
 # ex: syntax=ruby ts=2 sw=2 si et
-require 'puppetx/ip'
+begin
+  require 'puppetx/ip'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppetx/ip')
+end
 
 module Puppet::Parser::Functions
   newfunction(:ip_netmask, :type => :rvalue) do |args|

--- a/lib/puppet/parser/functions/ip_network.rb
+++ b/lib/puppet/parser/functions/ip_network.rb
@@ -1,5 +1,11 @@
 # ex: syntax=ruby ts=2 sw=2 si et
-require 'puppetx/ip'
+begin
+  require 'puppetx/ip'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppetx/ip')
+end
 
 module Puppet::Parser::Functions
   newfunction(:ip_network, :type => :rvalue) do |args|

--- a/lib/puppet/parser/functions/ip_network_size.rb
+++ b/lib/puppet/parser/functions/ip_network_size.rb
@@ -1,5 +1,11 @@
 # ex: syntax=ruby ts=2 sw=2 si et
-require 'puppetx/ip'
+begin
+  require 'puppetx/ip'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppetx/ip')
+end
 
 module Puppet::Parser::Functions
   newfunction(:ip_network_size, :type => :rvalue) do |args|

--- a/lib/puppet/parser/functions/ip_offset.rb
+++ b/lib/puppet/parser/functions/ip_offset.rb
@@ -1,5 +1,11 @@
 # ex: syntax=ruby ts=2 sw=2 si et
-require 'puppetx/ip'
+begin
+  require 'puppetx/ip'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppetx/ip')
+end
 
 module Puppet::Parser::Functions
   newfunction(:ip_offset, :type => :rvalue) do |args|

--- a/lib/puppet/parser/functions/ip_prefixlength.rb
+++ b/lib/puppet/parser/functions/ip_prefixlength.rb
@@ -1,5 +1,11 @@
 # ex: syntax=ruby ts=2 sw=2 si et
-require 'puppetx/ip'
+begin
+  require 'puppetx/ip'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppetx/ip')
+end
 
 module Puppet::Parser::Functions
   newfunction(:ip_prefixlength, :type => :rvalue) do |args|

--- a/lib/puppet/parser/functions/ip_split.rb
+++ b/lib/puppet/parser/functions/ip_split.rb
@@ -1,5 +1,11 @@
 # ex: syntax=ruby ts=2 sw=2 si et
-require 'puppetx/ip'
+begin
+  require 'puppetx/ip'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppetx/ip')
+end
 
 module Puppet::Parser::Functions
   newfunction(:ip_split, :type => :rvalue) do |args|

--- a/lib/puppet/parser/functions/ip_subnet.rb
+++ b/lib/puppet/parser/functions/ip_subnet.rb
@@ -1,5 +1,11 @@
 # ex: syntax=ruby ts=2 sw=2 si et
-require 'puppetx/ip'
+begin
+  require 'puppetx/ip'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppetx/ip')
+end
 
 module Puppet::Parser::Functions
   newfunction(:ip_subnet, :type => :rvalue) do |args|

--- a/lib/puppet/parser/functions/ip_supernet.rb
+++ b/lib/puppet/parser/functions/ip_supernet.rb
@@ -1,5 +1,11 @@
 # ex: syntax=ruby ts=2 sw=2 si et
-require 'puppetx/ip'
+begin
+  require 'puppetx/ip'
+rescue LoadError => e
+  # work around for puppet bug SERVER-973
+  Puppet.info('Puppet did not autoload from the lib directory... falling back to relative path load.')
+  require File.join(File.expand_path(File.join(__FILE__, '../../../..')), 'puppetx/ip')
+end
 
 module Puppet::Parser::Functions
   newfunction(:ip_supernet, :type => :rvalue) do |args|


### PR DESCRIPTION
Some versions of puppet have a regression and can't load auxilliary code from
the module's lib directory. See
https://tickets.puppetlabs.com/browse/SERVER-973

Fixes #3 
