### PR TITLE
Add support for “address/mask” format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ necessary to use any of its features.
 
 ## Conventions
 
-This documentation refers to an IP address suffixed with a CIDR prefix length
-as an IP/CIDR.
+This documentation refers to an IP address suffixed, with either a CIDR prefix
+length or a netmask, as an IP/CIDR.
 
 ## Usage
 

--- a/lib/puppetx/ip.rb
+++ b/lib/puppetx/ip.rb
@@ -9,9 +9,19 @@ class PuppetX::Ip
 
   def initialize(cidr)
     @cidr = IPAddr.new(cidr)
-    (addr, prefixlen) = cidr.split(/\//)
+    (addr, mask) = cidr.split(/\//)
     @address = IPAddr.new(addr)
-    prefixlen ||= unicast_prefixlength
+    if mask.nil?
+      prefixlen = unicast_prefixlength
+    elsif mask =~ /\A\d+\z/
+      prefixlen = mask.to_i
+    else
+      m = IPAddr.new(mask)
+      if m.family != @address.family
+        raise ArgumentError, "address family is not same"
+      end
+      prefixlen = m.to_i.to_s(2).count('1')
+    end
     @prefixlength = prefixlen.to_i
   end
 


### PR DESCRIPTION
Based loosely on code from Ruby’s standard library’s `IPAddress#mask!`.

Disclaimer: I ended up not using using this module, so the changes I submit here are not currently being used in production.