### PR TITLE
Use integer math instead of array indexing

### DIFF
--- a/spec/functions/ip_increment_spec.rb
+++ b/spec/functions/ip_increment_spec.rb
@@ -7,4 +7,5 @@ describe 'ip_increment' do
     it { should run.with_params('fd00::fe/119','2').and_return('fd00::100/119') }
     it { should run.with_params('fd00::1/120').and_return('fd00::2/120') }
     it { should run.with_params('fd00::ff/120').and_raise_error(ArgumentError) }
+    it { should run.with_params('2600:3c00::f03c:91ff:fe96:432a/64',5).and_return('2600:3c00::f03c:91ff:fe96:432f/64') }
 end


### PR DESCRIPTION
Compute offset addresses, address offsets, and network sizes with integer math
instead of realizing ranges of addresses as array and indexing them. This makes
operations on large subnets much more efficient. In particular, it can work on
IPv6 addresses with a 64 bit prefix length now.

Fixes #6 